### PR TITLE
Add the type attribute on button

### DIFF
--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -7,6 +7,7 @@
   export let buttonType: ButtonTypeEnum;
   export let disabled: boolean = false;
   export let tooltip: boolean = false;
+  export let type: 'button' | 'submit' | 'reset' | null | undefined = 'button';
 
   const dispatch = createEventDispatcher();
 
@@ -16,6 +17,7 @@
 </script>
 
 <button
+  type="{type}"
   on:click={handleButtonClick}
   {disabled}
   class:primary={buttonType === ButtonTypeEnum.PRIMARY}


### PR DESCRIPTION
When not set, the type attribute value depend on where the button is. If it's inside a form element the default value is submit while it's button otherwise. 
I added the ability to set the value while adding « type="button" by default.